### PR TITLE
No gloves on the sander

### DIFF
--- a/syllabuses/Workshop/Sander/syllabus.md
+++ b/syllabuses/Workshop/Sander/syllabus.md
@@ -7,6 +7,7 @@
 
 ### Entanglement risks
  * No loose clothing or cables.
+ * No gloves.
  * Long hair must be tied back.
  * Fingers must be kept at least 10cm away from moving parts.
  * Particular care must be taken around the gap where the belt disappears.


### PR DESCRIPTION
This adds a note to the sander syllabus about not wearing gloves. I think the risk of gloves getting caught on the abrasive or in other moving parts far outweighs any benefits on this tool. This lines up with HSE's advice from [Health and safety in engineering workshops HSG129](http://www.hse.gov.uk/pUbns/priced/hsg129.pdf) that says:
 > Use personal protective equipment such as gloves, gauntlets and aprons, but only where these do not add to other risks from machinery, such as entanglement.