### PR TITLE
Reorder laser cutter training

### DIFF
--- a/syllabuses/G2/Big Laser Cutter/syllabus.md
+++ b/syllabuses/G2/Big Laser Cutter/syllabus.md
@@ -4,13 +4,13 @@
 
 ### Materials
 
-* Can catch fire
+* Can catch fire (laser cutter must not be left unattended)
 * Can produce toxic fumes
 
 ### Laser
 
-* High-power laser can cause burns or severe eye damage
-* Laser compartment must remain closed
+* High-power laser can cause burns, severe eye damage or blindness
+* Laser compartment must remain closed, and the lid-sensor must not be bypassed
 
 ### Electricity
 
@@ -31,6 +31,15 @@
 
 ## Usage
 
+### Hazards
+
+* The laser can cause burns, severe eye damage and blindness
+* The laser compartment must remain closed, and the lid-sensor must not be bypassed
+* The laser cutter contains high voltages (2kV, 240V) and users must keep clear
+  of the wiring in the laser compartment and control panel
+* There is a risk of fire with **any** material and the laser cutter must not be
+  left unattended, even for a minute (there is pause button and an emergency stop)
+
 ### Starting of the machine
 
 * Check there are no obstacles for when the laser cutter moves to the home position
@@ -40,23 +49,7 @@
 * Power on the machine (green button)
 * Ensure the internal air assist is running (unless cutting paper)
 * Ensure the chiller is running
-  * If it is not, alarm will continue sounding for more than a second and machine should not be used.
-
-### Stopping of the machine
-
-* Return the laser to the home position ("Datum" button)
-* Power off the machine (red button/key switch)
-* The E-stop should be pressed in an emergency, this will cut power to the laser
-* Remember to log out if leaving the machine unattended for any period of time
-
-### Hazards
-
-* The laser can cause burns and blindness
-* The laser compartment must remain closed, and the lid-sensor must not be bypassed
-* The laser cutter contains high voltages (2kV, 240V) and users must keep clear
-  of the wiring in the laser compartment and control panel
-* There is a risk of fire with **any** material and the laser cutter must not be
-  left unattended, even for a minute (there is pause button and an emergency stop)
+  * If it is not, alarm will continue sounding for more than a second and machine should not be used
 
 ### General
 
@@ -72,10 +65,16 @@
 * Using the cutter's control panel to move the head/carriage (don't move it
   outside the allowed area because there is no protection against this)
 * Positioning the workpiece and setting Z (vertical) alignment
+  * The optimal position for the bed depends on the material but is usually
+    about 1cm above the height of the metal frame enclosure around the bed
+  * Don't leave it too high because the laser head/carriage may hit it
+  * Don't use the bed height for focusing, raise the laser head so that it won't
+    hit the material
 * Focusing the laser
   * Place the 12mm focusing cylinder on the material under the laser and loosen
-    the ring on the laser head/carriage to drop it onto the material so that the
-    air flow stops, then tighten the ring and remove the focusing cylinder
+    (clockwise) the top ring on the laser head/carriage to drop it onto the
+    material so that the air flow stops, then tighten the ring (counter-clockwise)
+    and remove the focusing cylinder
 * Using the test button before cutting (the red light indicates the outer
   boundary of the cutting/engraving area)
 
@@ -94,6 +93,13 @@
 * Consult the complete list of materials on the wiki page
 * Ask a maintainer if you are unsure of suitability
 
+### Stopping of the machine
+
+* The E-stop should be pressed in an emergency, this will cut power to the laser
+* Return the laser to the home position ("Datum" button)
+* Power off the machine (red button/key switch)
+* Remember to log out if leaving the machine unattended for any period of time
+
 ### Post Cutting/Engraving
 
 * Once you have finished your work, turn off the laser cutter, log out of the access control, and clean up the bed
@@ -101,27 +107,31 @@
 
 ## Maintenance
 
-### Basic
+### Basic (mandatory)
 
 #### Removing dirt and debris
 
 * Remove large debris by hand
 * Use vacuum cleaner to remove small debris
 
-#### Checking alignment of visible guide laser
-
-1. Put scrap material in the laser cutter and focus
-2. Close the lid
-3. Briefly press and release the "Laser" button to fire the laser
-4. Open the lid and align the guide laser with the mark on the material
-
-### Intermediate
+### Intermediate (optional)
 
 * Cleaning mirrors and lens
 * Checking alignment of laser
 * Minor corrections of alignment (mirrors 2 and 3 only)
 
-### Advanced
+#### Checking alignment of visible guide laser
+
+Don't do this unless the guide laser is obviously wrong because it will wear
+out the screw holding the guide laser in the aligned position.
+
+1. Put scrap material in the laser cutter and focus
+2. Close the lid
+3. Briefly press and release the "Laser" button to fire the laser
+4. Open the lid
+5. Align the guide laser with the mark on the material
+
+### Advanced (optional)
 
 * Removal of bed for extended cleaning
 * Full alignment

--- a/syllabuses/G2/Small Laser Cutter/syllabus.md
+++ b/syllabuses/G2/Small Laser Cutter/syllabus.md
@@ -4,13 +4,13 @@
 
 ### Materials
 
-* Can catch fire
+* Can catch fire (laser cutter must not be left unattended)
 * Can produce toxic fumes
 
 ### Laser
 
-* High-power laser can cause burns or severe eye damage
-* Laser compartment must remain closed
+* High-power laser can cause burns, severe eye damage or blindness
+* Laser compartment must remain closed, and the lid-sensor must not be bypassed
 
 ### Electricity
 
@@ -30,22 +30,6 @@
 
 ## Usage
 
-### Starting of the machine
-
-* Check there are no obstacles for when the laser cutter moves to the home position
-* Tap your tag on the access control
-* Ensure the external extractor fan is running
-* Release the E-Stop
-* Power on the machine (key switch)
-* Ensure the internal air pump is running (unless cutting paper)
-
-### Stopping of the machine
-
-* Return the laser to the home position ("Datum" button)
-* Power off the machine (red button/key switch)
-* The E-stop should be pressed in an emergency, this will cut power to the laser
-* Remember to log out if leaving the machine unattended for any period of time
-
 ### Hazards
 
 * The laser can cause burns and blindness
@@ -54,6 +38,15 @@
   of the wiring in the laser compartment and control panel
 * There is a risk of fire with **any** material and the laser cutter must not be
   left unattended, even for a minute (there is pause button and an emergency stop)
+
+### Starting of the machine
+
+* Check there are no obstacles for when the laser cutter moves to the home position
+* Tap your tag on the access control
+* Ensure the external extractor fan is running
+* Release the E-Stop
+* Power on the machine (key switch)
+* Ensure the internal air pump is running (unless cutting paper)
 
 ### General
 
@@ -88,6 +81,13 @@
 * Consult the complete list of materials on the wiki page
 * Ask a maintainer if you are unsure of suitability
 
+### Stopping of the machine
+
+* The E-stop should be pressed in an emergency, this will cut power to the laser
+* Return the laser to the home position ("Datum" button)
+* Power off the machine (red button/key switch)
+* Remember to log out if leaving the machine unattended for any period of time
+
 ### Post Cutting/Engraving
 
 * Once you have finished your work, turn off the laser cutter, log out of the access control, and clean up the bed
@@ -95,27 +95,31 @@
 
 ## Maintenance
 
-### Basic
+### Basic (mandatory)
 
 #### Removing dirt and debris
 
 * Remove large debris by hand
 * Use vacuum cleaner to remove small debris
 
-#### Checking alignment of visible guide laser
-
-1. Put scrap material in the laser cutter and focus
-2. Close the lid
-3. Briefly press and release the "Laser" button to fire the laser
-4. Open the lid and align the guide laser with the mark on the material
-
-### Intermediate
+### Intermediate (optional)
 
 * Cleaning mirrors and lens
 * Checking alignment of laser
 * Minor corrections of alignment (mirrors 2 and 3 only)
 
-### Advanced
+#### Checking alignment of visible guide laser
+
+Don't do this unless the guide laser is obviously wrong because it will wear
+out the screw holding the guide laser in the aligned position.
+
+1. Put scrap material in the laser cutter and focus
+2. Close the lid
+3. Briefly press and release the "Laser" button to fire the laser
+4. Open the lid
+5. Align the guide laser with the mark on the material
+
+### Advanced (optional)
 
 * Removal of bed for extended cleaning
 * Full alignment


### PR DESCRIPTION
Hazards should come first, especially because the training starts with the safety section so it's just a repeat. Make these messages the same to avoid repeating things in different ways.

Move stopping the laser to later, so that the training can be completed in order.

Make the basic maintenance mandatory and move alignment to the intermediate section which is now marked as optional.